### PR TITLE
fix: Use xorriso to extract iso images

### DIFF
--- a/container.ini
+++ b/container.ini
@@ -25,7 +25,7 @@ fence-agents
 wget
 vim
 ntp
-p7zip-full
+xorriso
 
 [pkgs-distro-amd64]
 # Distribution packages

--- a/scripts/python/cobbler_add_distros.py
+++ b/scripts/python/cobbler_add_distros.py
@@ -73,8 +73,8 @@ def extract_iso_images(path):
             # If dest dir already exists continue to next file
             if not os.path.isdir(dest_dir):
                 os.mkdir(dest_dir)
-                os.chdir(dest_dir)
-                _bash_cmd('7z x %s' % (path + _file))
+                _bash_cmd('xorriso -osirrox on -indev %s -extract / %s' %
+                          ((path + _file), dest_dir))
                 _bash_cmd('chmod 755 $(find %s -type d)' % dest_dir)
 
             # Do not return paths to "mini" isos


### PR DESCRIPTION
Use xorriso instead of 7z to extract iso images. Installation files must
retain their original names but 7z limits filename character length.

Change-Id: I2ad6f3677eab86e4eb3da2d27c8a137bcac40391