### PR TITLE
fix: Do not require 'networks' key in config file

### DIFF
--- a/scripts/python/lib/config.py
+++ b/scripts/python/lib/config.py
@@ -2502,4 +2502,7 @@ class Config(object):
             dict: Network definitions
         """
 
-        return self.cfg.networks
+        if self.CfgKey.NETWORKS in self.cfg:
+            return self.cfg.networks
+        else:
+            return []


### PR DESCRIPTION
The top level 'config.yml' key 'networks' should be optional.