### PR TITLE
fix: Do not require 'node_templates: os: users:'

### DIFF
--- a/scripts/python/cobbler_add_systems.py
+++ b/scripts/python/cobbler_add_systems.py
@@ -126,17 +126,20 @@ def cobbler_add_systems():
         if raid1_enabled:
             ks_meta += 'raid1_enabled=true '
         users = inv.get_nodes_os_users(index)
-        for user in users:
-            if INV_OS_NAME in user and user[INV_OS_NAME] != 'root':
-                ks_meta += 'default_user=%s ' % user[INV_OS_NAME]
-                LOG.debug("%s: Using \'%s\' as default user" %
-                          (hostname, user[INV_OS_NAME]))
-                if INV_OS_PASSWORD in user:
-                    ks_meta += ('passwd=%s passwdcrypted=true ' %
-                                user[INV_OS_PASSWORD])
-                break
+        if users is not None:
+            for user in users:
+                if INV_OS_NAME in user and user[INV_OS_NAME] != 'root':
+                    ks_meta += 'default_user=%s ' % user[INV_OS_NAME]
+                    LOG.debug("%s: Using \'%s\' as default user" %
+                              (hostname, user[INV_OS_NAME]))
+                    if INV_OS_PASSWORD in user:
+                        ks_meta += ('passwd=%s passwdcrypted=true ' %
+                                    user[INV_OS_PASSWORD])
+                    break
+            else:
+                LOG.debug("%s: No default user found" % hostname)
         else:
-            LOG.debug("%s: No default user found" % hostname)
+            LOG.debug("%s: No users defined" % hostname)
         if ks_meta != "":
             cobbler_server.modify_system(
                 new_system_create,


### PR DESCRIPTION
The 'users' list in 'node_templates: os' should be optional.