### PR TITLE
fix: Ignore ANSIBLE0014 in tox ansible-lint env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ basepython = python2.7
 commands =
     # Perform an Ansible lint check
     bash -c "find {toxinidir} -name '*.yml' -o -name '*.yaml' | xargs \
-    ansible-lint -x ANSIBLE0006,ANSIBLE0012,ANSIBLE0013,ANSIBLE0016"
+    ansible-lint -x ANSIBLE0006,ANSIBLE0012,ANSIBLE0013,ANSIBLE0014,ANSIBLE0016"
 
 [testenv:commit_message_validate]
 basepython = python2.7


### PR DESCRIPTION
Running the tox ansible-lint environment results in the following error:

[ANSIBLE0014] Environment variables don't work as part of command
/home/jwcarman/projects/ibm/cluster-genesis/playbooks/tasks/cmd_bootstrap.yml:18
Task/Handler: Run Bootstrap Command

The error is generated due to using jinja2 variables inside the 'args'
value, _not_ environment variables. This has been tested (lightly) but I
think it's safe to ignore this error class for now to allow tox to run
cleanly.