### PR TITLE
fix: Ignore node template items with empty values

### DIFF
--- a/scripts/python/lib/config.py
+++ b/scripts/python/lib/config.py
@@ -1781,12 +1781,14 @@ class Config(object):
                 node_template_index):
             if_labels.append(interface)
 
-        if self.CfgKey.INTERFACES in node_template:
+        if (self.CfgKey.INTERFACES in node_template and
+                node_template[self.CfgKey.INTERFACES] is not None):
             for interface in node_template[self.CfgKey.INTERFACES]:
                 if interface not in if_labels:
                     if_labels.append(interface)
 
-        if self.CfgKey.NETWORKS in node_template:
+        if (self.CfgKey.NETWORKS in node_template and
+                node_template[self.CfgKey.NETWORKS] is not None):
             for network in node_template[self.CfgKey.NETWORKS]:
                 for network_def in network_defs:
                     if network == network_def[self.CfgKey.LABEL]:


### PR DESCRIPTION
The 'interfaces' and 'network' lists defined within a 'node_templates'
item are optional. If the key is included without a value then it will
now be treated as if it were not defined.