### PR TITLE
feat: Allow merge commits

### DIFF
--- a/tests/commit_message_validate.py
+++ b/tests/commit_message_validate.py
@@ -28,7 +28,7 @@ def get_head_commit_message():
 
 valid_subject_tags = [
     'feat:', 'fix:', 'docs:', 'style:', 'refactor:', 'test:', 'chore:',
-    'Revert']
+    'Revert', 'Merge']
 no_errors = True
 errors = []
 
@@ -37,7 +37,7 @@ for i, line in enumerate(get_head_commit_message().splitlines()):
         if line.split()[0] not in valid_subject_tags:
             no_errors = False
             errors.append("Subject line does not start with valid tag")
-        if line.split()[0] != 'Revert':
+        if line.split()[0] not in ['Revert', 'Merge']:
             if line.split()[1][0].islower():
                 no_errors = False
                 errors.append("Subject line first word after tag is not "


### PR DESCRIPTION
Modify commit message validation rules to allow 'Merge' as a subject
tag. When a 'Merge' tag is used the subject length is not limited to 50
characters.